### PR TITLE
Fix 10.10 compatibility issue.

### DIFF
--- a/Pod/Classes/NSBundle+LoginItem.m
+++ b/Pod/Classes/NSBundle+LoginItem.m
@@ -90,9 +90,10 @@
             LSSharedFileListItemRef item = (__bridge LSSharedFileListItemRef)sharedFile;
             
             CFURLRef appURL = NULL;
-            LSSharedFileListItemResolve(item, 0, (CFURLRef *)&appURL, NULL);
-            if (!appURL) {
-                continue;
+            if (floor(NSAppKitVersionNumber) > NSAppKitVersionNumber10_9) {
+                appURL = LSSharedFileListItemCopyResolvedURL(item, kLSSharedFileListNoUserInteraction, NULL);
+            } else {
+                LSSharedFileListItemResolve(item, 0, (CFURLRef *)&appURL, NULL);
             }
 
             NSString *resolvedApplicationPath = [(__bridge NSURL *)appURL path];


### PR DESCRIPTION
use LSSharedFileListItemCopyResolvedURL instead of
LSSharedFileListItemResolve on 10.10.
